### PR TITLE
Bump LIBSVM version to 0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 [compat]
 DataStructures = "0.18.9"
 KernelFunctions = "0.10.5"
-LIBSVM = "0.6"
+LIBSVM = "0.7"
 LightGraphs = "1.3"
 SimpleValueGraphs = "0.3"
 ThreadsX = "0.1"

--- a/src/GraphKernels.jl
+++ b/src/GraphKernels.jl
@@ -55,7 +55,7 @@ include("integrations/LIBSVM.jl")
 
 Simple k-fold cross validation implementation for quick testing during development.
 """
-function k_fold_cross_validation(kernel::AbstractGraphKernel, graphs; k_folds=5, class_key=1, kwargs...)
+function k_fold_cross_validation(kernel::KernelFunctions.Kernel, graphs::AbstractVector{<:AbstractGraph}; k_folds=5, class_key=1, kwargs...)
 
     n = length(graphs)
     indices = randperm(MersenneTwister(123), n)


### PR DESCRIPTION
The svmtrain and svmpredict functions slightly changed in 0.7 for custom
kernels, therefore some code had to be changed.